### PR TITLE
Use tuple spec instead of deprecated worker()

### DIFF
--- a/en/lessons/advanced/gen-stage.md
+++ b/en/lessons/advanced/gen-stage.md
@@ -210,8 +210,8 @@ def start(_type, _args) do
 
   children = [
     {GenstageExample.Producer, 0},
-    GenstageExample.ProducerConsumer,
-    GenstageExample.Consumer
+    {GenstageExample.ProducerConsumer, []},
+    {GenstageExample.Consumer, []}
   ]
 
   opts = [strategy: :one_for_one, name: GenstageExample.Supervisor]
@@ -247,10 +247,16 @@ Let's make some adjustments for multiple workers by modifying `lib/genstage_exam
 
 ```elixir
 children = [
-  worker(GenstageExample.Producer, [0]),
-  worker(GenstageExample.ProducerConsumer, []),
-  worker(GenstageExample.Consumer, [], id: 1),
-  worker(GenstageExample.Consumer, [], id: 2)
+  {GenstageExample.Producer, 0},
+  {GenstageExample.ProducerConsumer, []},
+  %{
+    id: 1,
+    start: {GenstageExample.Consumer, :start_link, [[]]}
+  },
+  %{
+    id: 2,
+    start: {GenstageExample.Consumer, :start_link, [[]]}
+  },
 ]
 ```
 

--- a/en/lessons/advanced/gen-stage.md
+++ b/en/lessons/advanced/gen-stage.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.2
+version: 1.1.0
 title: GenStage
 ---
 
@@ -67,7 +67,7 @@ Let's update our dependencies in `mix.exs` to include `gen_stage`:
 ```elixir
 defp deps do
   [
-    {:gen_stage, "~> 0.11"},
+    {:gen_stage, "~> 1.0.0"},
   ]
 end
 ```
@@ -136,7 +136,7 @@ defmodule GenstageExample.ProducerConsumer do
 
   require Integer
 
-  def start_link do
+  def start_link(_initial) do
     GenStage.start_link(__MODULE__, :state_doesnt_matter, name: __MODULE__)
   end
 
@@ -177,7 +177,7 @@ Since consumers and producer-consumers are so similar our code won't look much d
 defmodule GenstageExample.Consumer do
   use GenStage
 
-  def start_link do
+  def start_link(_initial) do
     GenStage.start_link(__MODULE__, :state_doesnt_matter)
   end
 
@@ -209,9 +209,9 @@ def start(_type, _args) do
   import Supervisor.Spec, warn: false
 
   children = [
-    worker(GenstageExample.Producer, [0]),
-    worker(GenstageExample.ProducerConsumer, []),
-    worker(GenstageExample.Consumer, [])
+    {GenstageExample.Producer, 0},
+    GenstageExample.ProducerConsumer,
+    GenstageExample.Consumer
   ]
 
   opts = [strategy: :one_for_one, name: GenstageExample.Supervisor]


### PR DESCRIPTION
This pull request contains a series of changes I had to make to use make the tutorial work.

1. It seems that the `worker()` style child specifications are now deprecated in favour of passing a tuple-style specification - that's what I've updated it to.
2. The version of gen_stage was old, I've upgraded that
3. `start_link` in consumer.ex and producer_consumer.ex needed a (disused) parameter added 